### PR TITLE
Unidata

### DIFF
--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -209,7 +209,7 @@ resource "openstack_compute_instance_v2" "bastion" {
 }
 
 resource "openstack_compute_instance_v2" "k8s_master" {
-  name              = "${var.cluster_name}-k8s-master-${count.index + 1}"
+  name              = "${var.cluster_name}-${count.index + 1}"
   count             = var.number_of_k8s_masters
   availability_zone = element(var.az_list, count.index)
   image_id          = var.master_root_volume_size_in_gb == 0 ? local.image_to_use_master : null
@@ -256,7 +256,7 @@ resource "openstack_compute_instance_v2" "k8s_master" {
 }
 
 resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
-  name              = "${var.cluster_name}-k8s-master-ne-${count.index + 1}"
+  name              = "${var.cluster_name}-ne-${count.index + 1}"
   count             = var.number_of_k8s_masters_no_etcd
   availability_zone = element(var.az_list, count.index)
   image_id          = var.master_root_volume_size_in_gb == 0 ? local.image_to_use_master : null
@@ -344,7 +344,7 @@ resource "openstack_compute_instance_v2" "etcd" {
 }
 
 resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip" {
-  name              = "${var.cluster_name}-k8s-master-nf-${count.index + 1}"
+  name              = "${var.cluster_name}-nf-${count.index + 1}"
   count             = var.number_of_k8s_masters_no_floating_ip
   availability_zone = element(var.az_list, count.index)
   image_id          = var.master_root_volume_size_in_gb == 0 ? local.image_to_use_master : null
@@ -386,7 +386,7 @@ resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip" {
 }
 
 resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip_no_etcd" {
-  name              = "${var.cluster_name}-k8s-master-ne-nf-${count.index + 1}"
+  name              = "${var.cluster_name}-ne-nf-${count.index + 1}"
   count             = var.number_of_k8s_masters_no_floating_ip_no_etcd
   availability_zone = element(var.az_list, count.index)
   image_id          = var.master_root_volume_size_in_gb == 0 ? local.image_to_use_master : null

--- a/inventory/kubejetstream/cluster.tfvars
+++ b/inventory/kubejetstream/cluster.tfvars
@@ -71,3 +71,6 @@ k8s_allowed_remote_ips = ["0.0.0.0/0"]
 
 # have Kubernetes traffic use the internal IP
 use_access_ip = 0
+
+# Uncomment below and edit to set dns-domain network property
+# network_dns_domain = "<project-ID>.projects.jetstream-cloud.org."


### PR DESCRIPTION
Shorten the name of k8s master nodes as JetStream2 uses instance names to dynamically create DNS names, leading to long DNS names otherwise.

Tell terraform to set the dns-domain property on the network it creates.

@julienchastang