### PR TITLE
Have k8s master nodes ignore updated image IDs

### DIFF
--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -216,6 +216,9 @@ resource "openstack_compute_instance_v2" "k8s_master" {
   flavor_id         = var.flavor_k8s_master
   key_pair          = openstack_compute_keypair_v2.k8s.name
 
+  lifecycle {
+    ignore_changes  = [ image_id ]
+  }
 
   dynamic "block_device" {
     for_each = var.master_root_volume_size_in_gb > 0 ? [local.image_to_use_master] : []
@@ -263,6 +266,9 @@ resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
   flavor_id         = var.flavor_k8s_master
   key_pair          = openstack_compute_keypair_v2.k8s.name
 
+  lifecycle {
+    ignore_changes  = [ image_id ]
+  }
 
   dynamic "block_device" {
     for_each = var.master_root_volume_size_in_gb > 0 ? [local.image_to_use_master] : []
@@ -351,6 +357,10 @@ resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip" {
   flavor_id         = var.flavor_k8s_master
   key_pair          = openstack_compute_keypair_v2.k8s.name
 
+  lifecycle {
+    ignore_changes  = [ image_id ]
+  }
+
   dynamic "block_device" {
     for_each = var.master_root_volume_size_in_gb > 0 ? [local.image_to_use_master] : []
     content {
@@ -392,6 +402,10 @@ resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip_no_etcd" {
   image_id          = var.master_root_volume_size_in_gb == 0 ? local.image_to_use_master : null
   flavor_id         = var.flavor_k8s_master
   key_pair          = openstack_compute_keypair_v2.k8s.name
+
+  lifecycle {
+    ignore_changes  = [ image_id ]
+  }
 
   dynamic "block_device" {
     for_each = var.master_root_volume_size_in_gb > 0 ? [local.image_to_use_master] : []


### PR DESCRIPTION
OS images are regularly updated on JetStream2, resulting in changing
image IDs. Thus, when running `terraform apply` on an existing cluster
(for example, to up/downscale the cluster), terraform recieves a
different image ID than the one the cluster was first created with,
prompting terraform to destroy/re-creates VMs. This can cause loss of
data, particularly if the k8s master nodes are affected.

Add the [lifecycle](https://www.terraform.io/language/meta-arguments/lifecycle)
block to ensure changes to image IDs are ignored when updating k8s
master nodes.