### PR TITLE
Let neutron (openstack) do CIDR book-keeping

### DIFF
--- a/contrib/terraform/openstack/modules/network/main.tf
+++ b/contrib/terraform/openstack/modules/network/main.tf
@@ -21,7 +21,7 @@ resource "openstack_networking_subnet_v2" "k8s" {
   name            = "${var.cluster_name}-internal-network"
   count           = var.use_neutron
   network_id      = openstack_networking_network_v2.k8s[count.index].id
-  cidr            = var.subnet_cidr
+  subnetpool_id   = var.subnetpool_id
   ip_version      = 4
   dns_nameservers = var.dns_nameservers
 }

--- a/contrib/terraform/openstack/modules/network/variables.tf
+++ b/contrib/terraform/openstack/modules/network/variables.tf
@@ -12,6 +12,12 @@ variable "dns_nameservers" {
 
 variable "subnet_cidr" {}
 
+variable "subnetpool_id" {
+  description = "Subnetpool ID block."
+  type        = string
+  default     = "be988956-1bfb-4828-b511-a58229fbd4ac"
+}
+
 variable "use_neutron" {}
 
 variable "router_id" {}

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -154,6 +154,11 @@ variable "subnet_cidr" {
   default     = "10.0.0.0/24"
 }
 
+variable "subnetpool_id" {
+  description = "Subnetpool ID block."
+  type        = string
+}
+
 variable "dns_nameservers" {
   description = "An array of DNS name server names used by hosts in this subnet."
   type        = list(string)

--- a/inventory/kubejetstream/cluster.tfvars
+++ b/inventory/kubejetstream/cluster.tfvars
@@ -54,8 +54,6 @@ flavor_k8s_node = "4"
 # Jetstream 2
 external_net = "3fe22c05-6206-4db2-9a13-44f04b6796e6"
 
-# subnet_cidr = "<cidr>"
-
 floatingip_pool = "public"
 
 # list of availability zones available in your OpenStack cluster
@@ -78,3 +76,7 @@ use_access_ip = 0
 # Reuse the auto allocated router, we do not want to waste floating IPs by having un-necessary routers
 # openstack router list, find the ID (first column) of the `auto_allocated_router`
 router_id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+# Default subnetpool ID for JetStream2; Let neutron (openstack) do the CIDR
+# book-keeping for you
+subnetpool_id = "be988956-1bfb-4828-b511-a58229fbd4ac"

--- a/k8s_configure_kubectl_locally.sh
+++ b/k8s_configure_kubectl_locally.sh
@@ -1,1 +1,1 @@
-sed -i 's/10\.0\.[[:digit:]]\.[[:digit:]]\+/'"$IP/g" inventory/$CLUSTER/artifacts/admin.conf
+sed -i 's/10\.0\.[[:digit:]]\+\.[[:digit:]]\+/'"$IP/g" inventory/$CLUSTER/artifacts/admin.conf


### PR DESCRIPTION
Virutal routers on JS2 should be used more sparingly, as they take up a
floating ip. Routers can be re-used as long as subnet CIDRs do not
overlap. This is ensured by telling terraform to create subnets through
JetStream2's default subnetpool.

Also, fix a sed command which only allowed for CIDRs of the form
`1.0.x.xxx`, ie only one digit in the third octet.