### PR TITLE
Bootstrap nfs-common for debian based systems

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-debian.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-debian.yml
@@ -11,6 +11,23 @@
   tags:
     - facts
 
+- name: Check if nfs-common is needed
+  raw: which mount.nfs
+  register: need_nfs
+  failed_when: false
+  changed_when: false
+  # This command should always run, even in check mode
+  check_mode: false
+  tags:
+    - facts
+- name: Install nfs-common
+  raw:
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y nfs-common
+  become: true
+  when:
+    - need_nfs.rc != 0
+
 - name: Check http::proxy in apt configuration files
   raw: apt-config dump | grep -qsi 'Acquire::http::proxy'
   register: need_http_proxy
@@ -46,7 +63,7 @@
 - name: Install python3
   raw:
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y python3-minimal nfs-common
+    DEBIAN_FRONTEND=noninteractive apt-get install -y python3-minimal
   become: true
   when:
     - need_bootstrap.rc != 0


### PR DESCRIPTION
CC: @julienchastang 

Separate `python3` and `nfs-common` installation during bootstrap. Fixes [this](https://github.com/zonca/jupyterhub-deploy-kubernetes-jetstream/issues/56#issuecomment-1679706495).

Has been tested when scaling an existing cluster using `k8s_scale.sh`, but not when running `k8s_install.sh` on a newly created one.