### PR TITLE
2.21.0 hybrid

### DIFF
--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -596,6 +596,7 @@ resource "openstack_compute_instance_v2" "k8s_nodes" {
   user_data         = each.value.cloudinit != null ? templatefile("${path.module}/templates/cloudinit.yaml.tmpl", {
     extra_partitions = each.value.cloudinit.extra_partitions
   }) : data.cloudinit_config.cloudinit.rendered
+  security_groups = var.port_security_enabled ? local.worker_sec_groups : null
 
   dynamic "block_device" {
     for_each = !local.k8s_nodes_settings[each.key].use_local_disk ? [local.k8s_nodes_settings[each.key].image_id] : []

--- a/inventory/kubejetstream/cluster.tfvars
+++ b/inventory/kubejetstream/cluster.tfvars
@@ -40,6 +40,7 @@ number_of_k8s_nodes = 1
 number_of_k8s_nodes_no_floating_ip = 0
 
 flavor_k8s_node = "4"
+# supplementary_node_groups = ["gpu-node"] # Uncomment when all nodes will be GPU nodes
 
 # GlusterFS
 # either 0 or more than one

--- a/inventory/kubejetstream/cluster.tfvars
+++ b/inventory/kubejetstream/cluster.tfvars
@@ -42,6 +42,45 @@ number_of_k8s_nodes_no_floating_ip = 0
 flavor_k8s_node = "4"
 # supplementary_node_groups = ["gpu-node"] # Uncomment when all nodes will be GPU nodes
 
+# BEGIN HYBRID CLUSTER CONFIG
+
+# # Set to true by default, but we make it explicit here
+# port_security_enabled = true
+
+# # Must be uncommented and set to 0 to use the k8s_nodes variable
+# number_of_k8s_nodes = 0
+# number_of_k8s_nodes_no_floating_ip = 0
+
+# # "<cluster-name>-k8s-node-" will be prepended to each key name and used to create the instance name.
+# # E.g the first item below would result in an instanced named "<cluster-name>-k8s-node-nf-cpu-1"
+# # For a full list of options see ./contrib/terraform/openstack/README.md#k8s_nodes
+# k8s_nodes = {
+#   "nf-cpu-1" = {
+#     "az" = "nova"
+#     "flavor": "4"
+#     "floating_ip": false
+#   },
+#   "nf-cpu-2" = {
+#     "az" = "nova"
+#     "flavor": "4"
+#     "floating_ip": false
+#   },
+#   "nf-gpu-1" = {
+#     "az" = "nova"
+#     "flavor": "10"
+#     "floating_ip": false
+#     "extra_groups": "gpu-node"
+#   },
+#   "nf-gpu-2" = {
+#     "az" = "nova"
+#     "flavor": "10"
+#     "floating_ip": false
+#     "extra_groups": "gpu-node"
+#   },
+# }
+
+# END HYBRID CLUSTER CONFIG
+
 # GlusterFS
 # either 0 or more than one
 #number_of_gfs_nodes_no_floating_ip = 0

--- a/inventory/kubejetstream/cluster.tfvars
+++ b/inventory/kubejetstream/cluster.tfvars
@@ -40,7 +40,11 @@ number_of_k8s_nodes = 1
 number_of_k8s_nodes_no_floating_ip = 0
 
 flavor_k8s_node = "4"
-# supplementary_node_groups = ["gpu-node"] # Uncomment when all nodes will be GPU nodes
+
+# # Uncomment when all nodes will be GPU nodes
+# # If you wish to use this var for another reason, add the ansible groups as a comma seperated list
+# # E.g "additional-group-1,additional-group2,etc"
+# supplementary_node_groups = "gpu-node"
 
 # BEGIN HYBRID CLUSTER CONFIG
 

--- a/inventory/kubejetstream/group_vars/gpu-node/containderd.yml
+++ b/inventory/kubejetstream/group_vars/gpu-node/containderd.yml
@@ -1,0 +1,54 @@
+---
+# Please see roles/container-engine/containerd/defaults/main.yml for more configuration options
+
+# containerd_storage_dir: "/var/lib/containerd"
+# containerd_state_dir: "/run/containerd"
+# containerd_oom_score: 0
+
+containerd_default_runtime: "nvidia"
+# containerd_snapshotter: "native"
+
+containerd_runc_runtime:
+  name: nvidia
+  type: "io.containerd.runc.v2"
+  engine: ""
+  root: ""
+  options:
+    BinaryName : '"/usr/bin/nvidia-container-runtime"'
+
+
+# containerd_additional_runtimes:
+# Example for Kata Containers as additional runtime:
+#   - name: kata
+#     type: "io.containerd.kata.v2"
+#     engine: ""
+#     root: ""
+
+# containerd_grpc_max_recv_message_size: 16777216
+# containerd_grpc_max_send_message_size: 16777216
+
+# containerd_debug_level: "info"
+
+# containerd_metrics_address: ""
+
+# containerd_metrics_grpc_histogram: false
+
+## An obvious use case is allowing insecure-registry access to self hosted registries.
+## Can be ipaddress and domain_name.
+## example define mirror.registry.io or 172.19.16.11:5000
+## set "name": "url". insecure url must be started http://
+## Port number is also needed if the default HTTPS port is not used.
+# containerd_insecure_registries:
+#   "localhost": "http://127.0.0.1"
+#   "172.19.16.11:5000": "http://172.19.16.11:5000"
+
+# containerd_registries:
+#   "docker.io": "https://registry-1.docker.io"
+
+# containerd_max_container_log_line_size: -1
+
+# containerd_registry_auth:
+#   - registry: 10.0.0.2:5000
+#     username: user
+#     password: pass
+


### PR DESCRIPTION
CC: @julienchastang 

Hey Andrea,

Apologies for the long PR description, but I feel like it contains some relevant information.

Here are the changes needed to deploy a hybrid cluster. In short, to deploy a hybrid cluster do everything as you normally would, with the exception of these 3 things:

1) Explicitly set `number_of_k8s_nodes` and `number_of_k8s_nodes_no_floating_ip` to `0`. This is *required*.
2) Declare the `k8s_nodes` variable. The availability zone (`av`), `flavor` and `floating_ip` are the only required fields
3) Specify which nodes will be GPU nodes by adding the `"extra_groups": "gpu-node"` value.

A few notes:

- The necessary changes to `containerd.yml` to enable the nvidia container runtime are contained in an ansible group_var file specific only to the "gpu-node" group. As such, there is no longer a need for a different `branch_v<version>_gpu` branch for anything other than book-keeping and documenting the changes necessary to enable GPU capability. Simply specify which nodes should be GPU enabled by adding them to the group, or if deploying a fully GPU cluster, add them all to the group with the `supplementary_node_groups` var. See my note on this in `cluster.tfvars`.

- When running a JupyterHub on top of a CPU/GPU hybrid cluster, it *may be* necessary to do two things: 1) create two separate single user images, one for CPU usage and one for GPU usage, and set the appropriate `kubespawner_override` values; and 2) disable the hook image puller and the continuous image puller (see the JHub config snippet below). This is because some GPU enabled singleuser images are ultimately based off of a CUDA image and will expect GPUs to be available, as is the case with the one [currently in your JupyterHub deployment repository](https://github.com/zonca/jupyterhub-deploy-kubernetes-jetstream/blob/master/gpu/nvidia-tensorflow-jupyterhub/Dockerfile). In other words, attempting to run this image in a hybrid cluster will result in some errors.

  I am currently working on creating some single user images that make this a non-problem by installing CUDA in a conda environment. You can see some preliminary work for this [here](https://github.com/ana-v-espinoza/science-gateway/blob/hybrid-gpu/jupyter-images/hybrid-gpu/Dockerfile). Expect a PR to address this problem in that repository soon.

  ```yaml
  prePuller:
    hook:
      enabled: false
    continuous:
      enabled: false
  ```

- In principle, this could be applied for things other than a CPU/GPU hybrid cluster. For example, we've ran across instances where multiple people are concurrently running computationally intensive tasks and crash the JupyterHub. The solution to this is to run the JHub "core" pods on a dedicated node, which probably can be ran on something smaller than the `m3.medium` that we typically use for our cluster. See more details about this [here](https://github.com/Unidata/science-gateway/tree/master/vms/jupyter#ensure-core-pods-are-scheduled-on-a-dedicated-node).

Let me know if you have any questions,

Ana