### PR TITLE
Use Ubuntu 22 for image

### DIFF
--- a/inventory/kubejetstream/cluster.tfvars
+++ b/inventory/kubejetstream/cluster.tfvars
@@ -2,7 +2,7 @@
 public_key_path = "~/.ssh/id_rsa.pub"
 
 # image to use for bastion, masters, standalone etcd instances, and nodes
-image = "Featured-Ubuntu20"
+image = "Featured-Ubuntu22"
 
 # user on the node (ex. core on Container Linux, ubuntu on Ubuntu, etc.)
 ssh_user = "ubuntu"


### PR DESCRIPTION
Ubuntu 20 no longer supports Jetstream2's GPU drivers: https://gitlab.com/jetstream-cloud/docs/-/issues/88