### PR TITLE
Address rate limits for large clusters

### DIFF
--- a/k8s_install.sh
+++ b/k8s_install.sh
@@ -1,2 +1,3 @@
 set -o nounset # fail if a variable is not defined
-ansible-playbook --become -i inventory/$CLUSTER/hosts cluster.yml -b -v --limit "${CLUSTER}*" --extra-vars="supplementary_addresses_in_ssl_keys=[\"$IP\"]"
+ansible-playbook --become -i inventory/$CLUSTER/hosts cluster.yml -b -v --limit "${CLUSTER}*" --extra-vars="supplementary_addresses_in_ssl_keys=[\"$IP\"]" \
+  -e '{"download_run_once":true}'

--- a/k8s_scale.sh
+++ b/k8s_scale.sh
@@ -1,2 +1,3 @@
 set -o nounset # fail if a variable is not defined
-ansible-playbook --become -i inventory/$CLUSTER/hosts scale.yml  --flush-cache -b -v --limit "${CLUSTER}*" --extra-vars="supplementary_addresses_in_ssl_keys=[\"$IP\"]"
+ansible-playbook --become -i inventory/$CLUSTER/hosts scale.yml  --flush-cache -b -v --limit "${CLUSTER}*" --extra-vars="supplementary_addresses_in_ssl_keys=[\"$IP\"]" \
+  -e '{"download_run_once":true}'


### PR DESCRIPTION
CC @julienchastang 

This PR addresses a potential issue created by DockerHub's new rate limit policy, which went into effect March 1, 2025:
https://docs.docker.com/docker-hub/usage/

It passes the `download_run_once: true' attribute to ansible that will download the docker images necessary for Kubespray to a single host then copy them over to all the other hosts as opposed to having each host pull every image.

This is documented by Kubespray [here](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/operations/large-deployments.md), and we have this technique in our own docs as well [here](https://github.com/Unidata/science-gateway/blob/master/openstack/readme.md#large-clusters-with-many-vms).